### PR TITLE
fix(ci): follow `@changesets/get-github-info` v1 API in the changelog generator

### DIFF
--- a/.changeset/changelog-generator.mjs
+++ b/.changeset/changelog-generator.mjs
@@ -1,9 +1,10 @@
 // `@changesets/get-github-info` is exports-only, which the `import` plugin's
 // node resolver does not read
 // eslint-disable-next-line import/no-unresolved
-import { getInfo, getInfoFromPullRequest } from "@changesets/get-github-info";
+import { getCommitInfo, getPullRequestInfo } from "@changesets/get-github-info";
 
 /** @typedef {import("@changesets/types").ChangelogFunctions} ChangelogFunctions */
+/** @typedef {{ commit: string | null, pull: string | null, user: string | null }} Links */
 
 /**
  * @returns {{ GITHUB_SERVER_URL: string }} value
@@ -32,11 +33,11 @@ const changelogFunctions = {
       await Promise.all(
         changesets.map(async (cs) => {
           if (cs.commit) {
-            const { links } = await getInfo({
+            const info = await getCommitInfo({
               repo: options.repo,
               commit: cs.commit,
             });
-            return links.commit;
+            return info && info.commit.markdownLink;
           }
         }),
       )
@@ -85,28 +86,35 @@ const changelogFunctions = {
       .split("\n")
       .map((l) => l.trimEnd());
 
+    /** @type {Links} */
     const links = await (async () => {
       if (prFromSummary !== undefined) {
-        let { links } = await getInfoFromPullRequest({
+        const info = await getPullRequestInfo({
           repo: options.repo,
           pull: prFromSummary,
         });
-        if (commitFromSummary) {
-          const shortCommitId = commitFromSummary.slice(0, 7);
-          links = {
-            ...links,
-            commit: `[\`${shortCommitId}\`](${GITHUB_SERVER_URL}/${options.repo}/commit/${commitFromSummary})`,
-          };
-        }
-        return links;
+        const commit = commitFromSummary
+          ? `[\`${commitFromSummary.slice(0, 7)}\`](${GITHUB_SERVER_URL}/${options.repo}/commit/${commitFromSummary})`
+          : (info && info.commit && info.commit.markdownLink) || null;
+
+        return {
+          commit,
+          pull: (info && info.pull.markdownLink) || null,
+          user: (info && info.author && info.author.markdownLink) || null,
+        };
       }
       const commitToFetchFrom = commitFromSummary || changeset.commit;
       if (commitToFetchFrom) {
-        const { links } = await getInfo({
+        const info = await getCommitInfo({
           repo: options.repo,
           commit: commitToFetchFrom,
         });
-        return links;
+
+        return {
+          commit: (info && info.commit.markdownLink) || null,
+          pull: (info && info.pull && info.pull.markdownLink) || null,
+          user: (info && info.author && info.author.markdownLink) || null,
+        };
       }
       return {
         commit: null,


### PR DESCRIPTION
Fixes the Release workflow, which has been failing on `main` since the dependency update in #696.

## The failure

[Run 33000715039](https://github.com/webpack/minimizer-webpack-plugin/actions/runs/33000715039/job/98283525714) dies as soon as `changeset version` loads `.changeset/changelog-generator.mjs`:

```
SyntaxError: The requested module '@changesets/get-github-info' does not provide an export named 'getInfo'
    at #asyncInstantiate (node:internal/modules/esm/module_job:327:21)
    ...
    at async getNewChangelogEntry (node_modules/@changesets/apply-release-plan/dist/index.mjs:323:30)
🦋 Exited with code 1
```

`npm ci` and the build both pass; the job never gets far enough to open a release pull request.

## Cause

#696 bumped `@changesets/get-github-info` to v1, which renamed both entry points and reshaped their return values. The generator still imported the v0 names, so the module failed to instantiate.

| v0 | v1 |
| --- | --- |
| `getInfo({ repo, commit })` | `getCommitInfo({ repo, commit })` |
| `getInfoFromPullRequest({ repo, pull })` | `getPullRequestInfo({ repo, pull })` |
| returns `{ user, pull, links: { commit, pull, user } }` — pre-rendered markdown strings | returns `{ commit, author?, pull? }` of `{ url, markdownLink, ... }` objects, or `undefined` when the commit / pull request is not found |

## The change

Call the new functions and rebuild the internal `{ commit, pull, user }` link record from their `markdownLink` fields, collapsing a missing result — or a missing `author` / `pull` — to `null`. The `pr:` / `commit:` / `author:` summary overrides behave as before, and the rendered changelog entries are unchanged.

## Verification

- Ran the real `changeset version` against a scratch copy of the repo with `fetch` stubbed. It completes and renders the pending changeset in the same shape as the existing entries:
  ```
  - minify source one language embeds in another - … (by [@octocat](…) in [#695](…))
  ```
- Smoke-tested `getReleaseLine` for the commit-only, PR-only, PR-plus-commit-override and no-metadata paths, plus `getDependencyReleaseLine` with and without updated dependencies.
- `eslint` and `prettier` are clean on the file.

Worth noting: v1 declares `engines.node` as `^22.11 || ^24 || >=26`. The Release workflow runs `lts/*` (Node 24), so CI is fine, but `changeset version` will no longer run locally on Node 18 or 20.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBkoHWr6p7NHqXt4ZP8v9N)_