### PR TITLE
refactor: validate options from webpack's validate hook

### DIFF
--- a/.changeset/validate-options-from-hook.md
+++ b/.changeset/validate-options-from-hook.md
@@ -1,0 +1,5 @@
+---
+"minimizer-webpack-plugin": minor
+---
+
+validate options from webpack's `validate` hook instead of from the constructor, so `validate: false` skips validation, falling back to `schema-utils` on webpack versions without the hook

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,7 @@
 const os = require("os");
 const path = require("path");
 
-const { validate } = require("schema-utils");
-
 const { minify } = require("./minify");
-const schema = require("./options.json");
 const {
   cleanCssMinify,
   cssnanoMinify,
@@ -194,6 +191,11 @@ const {
  * @typedef {BasePluginOptions & { minimizer: { implementation: MinimizerImplementation<T>, options: MinimizerOptions<T> } }} InternalPluginOptions
  */
 
+const VALIDATION_CONFIGURATION = {
+  name: "Terser Plugin",
+  baseDataPath: "options",
+};
+
 const getTraceMapping = memoize(() => require("@jridgewell/trace-mapping"));
 const getSerializeJavascript = memoize(() => require("./serialize-javascript"));
 
@@ -205,10 +207,15 @@ class TerserPlugin {
    * @param {BasePluginOptions & DefinedDefaultMinimizerAndOptions<T>=} options options
    */
   constructor(options) {
-    validate(/** @type {Schema} */ (schema), options || {}, {
-      name: "Terser Plugin",
-      baseDataPath: "options",
-    });
+    // Kept for `apply()`, which is where validation runs now: webpack owns when
+    // it happens, and skips it entirely for `validate: false`.
+    /**
+     * @private
+     * @type {BasePluginOptions & DefinedDefaultMinimizerAndOptions<T>}
+     */
+    this.rawOptions =
+      /** @type {BasePluginOptions & DefinedDefaultMinimizerAndOptions<T>} */
+      (options || {});
 
     // TODO handle json and etc in the next major release
     // TODO make `minimizer` option instead `minify` and `terserOptions` in the next major release, also rename `terserMinify` to `terserMinimize`
@@ -223,7 +230,7 @@ class TerserPlugin {
       parallel = true,
       include,
       exclude,
-    } = options || {};
+    } = this.rawOptions;
 
     // `terserOptions` is a deprecated alias of `minimizerOptions`; prefer the
     // new name when both are provided.
@@ -1169,11 +1176,60 @@ class TerserPlugin {
   }
 
   /**
+   * Validates the options the plugin was constructed with.
+   * @private
+   * @param {Compiler} compiler compiler
+   * @returns {void}
+   */
+  validateOptions(compiler) {
+    if (typeof compiler.validate === "function") {
+      compiler.validate(
+        () => /** @type {Schema} */ (require("./options.json")),
+        this.rawOptions,
+        VALIDATION_CONFIGURATION,
+      );
+
+      return;
+    }
+
+    // TODO remove in the next major release, when webpack >= 5.106 is the
+    // minimum and `compiler.validate` is always there.
+    const { validate } = require("schema-utils");
+
+    validate(
+      /** @type {Schema} */ (require("./options.json")),
+      this.rawOptions,
+      VALIDATION_CONFIGURATION,
+    );
+  }
+
+  /**
    * @param {Compiler} compiler compiler
    * @returns {void}
    */
   apply(compiler) {
     const pluginName = this.constructor.name;
+
+    let validated = false;
+    const validateOptions = () => {
+      if (validated) {
+        return;
+      }
+
+      validated = true;
+      this.validateOptions(compiler);
+    };
+
+    if (compiler.hooks.validate) {
+      compiler.hooks.validate.tap(pluginName, validateOptions);
+    }
+
+    // TODO remove in the next major release, once every supported webpack calls
+    // `validate` after it applies `optimization.minimizer`. Until then that hook
+    // reaches this plugin only where it sits in `plugins`, and webpack < 5.106
+    // has no such hook at all; `initialize` runs after either placement.
+    compiler.hooks.initialize.tap(pluginName, validateOptions);
+
     const availableNumberOfCores = TerserPlugin.getAvailableNumberOfCores(
       this.options.parallel,
     );

--- a/test/__snapshots__/TerserPlugin.test.js.snap
+++ b/test/__snapshots__/TerserPlugin.test.js.snap
@@ -491,6 +491,8 @@ exports[`MinimizerPlugin should work in multi compiler mode with the one plugin:
 exports[`MinimizerPlugin should work in multi compiler mode with the one plugin: compiler plugin count 1`] = `
 {
   "compilation": 1,
+  "initialize": 1,
+  "validate": 1,
 }
 `;
 
@@ -580,6 +582,8 @@ exports[`MinimizerPlugin should work in multi compiler mode: assets 3`] = `
 exports[`MinimizerPlugin should work in multi compiler mode: compiler plugin count 1`] = `
 {
   "compilation": 1,
+  "initialize": 1,
+  "validate": 1,
 }
 `;
 

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`validation should validate a minimizer added through \`optimization.minimizer\` 1`] = `
+"Invalid options object. Terser Plugin has been initialized using an options object that does not match the API schema.
+ - options has an unknown property 'unknown'. These properties are valid:
+   object { test?, include?, exclude?, minimizerOptions?, terserOptions?, extractComments?, parallel?, minify? }"
+`;
+
 exports[`validation validate 1`] = `
 "Invalid options object. Terser Plugin has been initialized using an options object that does not match the API schema.
  - options.test should be one of these:

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -1,168 +1,176 @@
 import MinimizerPlugin from "../src";
 
+import { getCompiler } from "./helpers";
+
+/**
+ * @param {EXPECTED_ANY} options plugin options
+ * @returns {import("webpack").Compiler} compiler
+ */
+const createCompiler = (options) =>
+  getCompiler({ plugins: [new MinimizerPlugin(options)] });
+
 describe("validation", () => {
   it("validate", () => {
-    /* eslint-disable no-new */
     expect(() => {
-      new MinimizerPlugin({ test: /foo/ });
+      createCompiler({ test: /foo/ });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ test: "foo" });
+      createCompiler({ test: "foo" });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ test: [/foo/] });
+      createCompiler({ test: [/foo/] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ test: [/foo/, /bar/] });
+      createCompiler({ test: [/foo/, /bar/] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ test: ["foo", "bar"] });
+      createCompiler({ test: ["foo", "bar"] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ test: [/foo/, "bar"] });
+      createCompiler({ test: [/foo/, "bar"] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ test: true });
+      createCompiler({ test: true });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ test: [true] });
+      createCompiler({ test: [true] });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ include: /foo/ });
+      createCompiler({ include: /foo/ });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ include: "foo" });
+      createCompiler({ include: "foo" });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ include: [/foo/] });
+      createCompiler({ include: [/foo/] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ include: [/foo/, /bar/] });
+      createCompiler({ include: [/foo/, /bar/] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ include: ["foo", "bar"] });
+      createCompiler({ include: ["foo", "bar"] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ include: [/foo/, "bar"] });
+      createCompiler({ include: [/foo/, "bar"] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ include: true });
+      createCompiler({ include: true });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ include: [true] });
+      createCompiler({ include: [true] });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ exclude: /foo/ });
+      createCompiler({ exclude: /foo/ });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ exclude: "foo" });
+      createCompiler({ exclude: "foo" });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ exclude: [/foo/] });
+      createCompiler({ exclude: [/foo/] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ exclude: [/foo/, /bar/] });
+      createCompiler({ exclude: [/foo/, /bar/] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ exclude: ["foo", "bar"] });
+      createCompiler({ exclude: ["foo", "bar"] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ exclude: [/foo/, "bar"] });
+      createCompiler({ exclude: [/foo/, "bar"] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ exclude: true });
+      createCompiler({ exclude: true });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ exclude: [true] });
+      createCompiler({ exclude: [true] });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ parallel: true });
+      createCompiler({ parallel: true });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ parallel: false });
+      createCompiler({ parallel: false });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ parallel: 2 });
+      createCompiler({ parallel: 2 });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ parallel: "2" });
+      createCompiler({ parallel: "2" });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ parallel: {} });
+      createCompiler({ parallel: {} });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ minify() {} });
+      createCompiler({ minify() {} });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ minify: [() => ({ code: "" })] });
+      createCompiler({ minify: [() => ({ code: "" })] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         minify: [() => ({ code: "" }), () => ({ code: "" })],
       });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ minify: [] });
+      createCompiler({ minify: [] });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ minify: true });
+      createCompiler({ minify: true });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ terserOptions: {} });
+      createCompiler({ terserOptions: {} });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ terserOptions: [{}] });
+      createCompiler({ terserOptions: [{}] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ terserOptions: [{}, {}] });
+      createCompiler({ terserOptions: [{}, {}] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ terserOptions: [] });
+      createCompiler({ terserOptions: [] });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ terserOptions: null });
+      createCompiler({ terserOptions: null });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         terserOptions: {
           ecma: undefined,
           parse: {},
@@ -181,31 +189,31 @@ describe("validation", () => {
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ terserOptions: { emca: 5 } });
+      createCompiler({ terserOptions: { emca: 5 } });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ extractComments: true });
+      createCompiler({ extractComments: true });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ extractComments: false });
+      createCompiler({ extractComments: false });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ extractComments: "comment" });
+      createCompiler({ extractComments: "comment" });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ extractComments: /comment/ });
+      createCompiler({ extractComments: /comment/ });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ extractComments() {} });
+      createCompiler({ extractComments() {} });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           condition: true,
         },
@@ -213,7 +221,7 @@ describe("validation", () => {
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           condition: "comment",
         },
@@ -221,7 +229,7 @@ describe("validation", () => {
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           condition: /comment/,
         },
@@ -229,7 +237,7 @@ describe("validation", () => {
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           condition() {},
         },
@@ -237,7 +245,7 @@ describe("validation", () => {
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           condition: {},
         },
@@ -245,7 +253,7 @@ describe("validation", () => {
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           filename: "test.js",
         },
@@ -253,7 +261,7 @@ describe("validation", () => {
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           filename() {},
         },
@@ -261,7 +269,7 @@ describe("validation", () => {
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           filename: true,
         },
@@ -269,7 +277,7 @@ describe("validation", () => {
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           banner: true,
         },
@@ -277,7 +285,7 @@ describe("validation", () => {
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           banner: "banner",
         },
@@ -285,7 +293,7 @@ describe("validation", () => {
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           banner() {},
         },
@@ -293,7 +301,7 @@ describe("validation", () => {
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         extractComments: {
           banner: /test/,
         },
@@ -301,39 +309,58 @@ describe("validation", () => {
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ extractComments: { unknown: true } });
+      createCompiler({ extractComments: { unknown: true } });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ unknown: true });
+      createCompiler({ unknown: true });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ minimizerOptions: {} });
+      createCompiler({ minimizerOptions: {} });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ minimizerOptions: [{}] });
+      createCompiler({ minimizerOptions: [{}] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ minimizerOptions: [{}, {}] });
+      createCompiler({ minimizerOptions: [{}, {}] });
     }).not.toThrow();
 
     expect(() => {
-      new MinimizerPlugin({ minimizerOptions: [] });
+      createCompiler({ minimizerOptions: [] });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({ minimizerOptions: null });
+      createCompiler({ minimizerOptions: null });
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new MinimizerPlugin({
+      createCompiler({
         minimizerOptions: { ecma: 5 },
         terserOptions: { ecma: 5 },
       });
     }).not.toThrow();
   });
+
+  it("should validate a minimizer added through `optimization.minimizer`", () => {
+    expect(() => {
+      getCompiler({
+        optimization: {
+          minimize: true,
+          minimizer: [new MinimizerPlugin({ unknown: true })],
+        },
+      });
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      getCompiler({
+        optimization: {
+          minimize: true,
+          minimizer: [new MinimizerPlugin({ parallel: 2 })],
+        },
+      });
+    }).not.toThrow();
+  });
 });
-/* eslint-enable no-new */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,11 @@ declare class TerserPlugin<T = import("terser").MinifyOptions> {
   );
   /**
    * @private
+   * @type {BasePluginOptions & DefinedDefaultMinimizerAndOptions<T>}
+   */
+  private rawOptions;
+  /**
+   * @private
    * @type {InternalPluginOptions<T>}
    */
   private options;
@@ -85,6 +90,13 @@ declare class TerserPlugin<T = import("terser").MinifyOptions> {
    * @returns {Promise<import("webpack").sources.Source>} the minified source, or the original
    */
   private renderEmbeddedSource;
+  /**
+   * Validates the options the plugin was constructed with.
+   * @private
+   * @param {Compiler} compiler compiler
+   * @returns {void}
+   */
+  private validateOptions;
   /**
    * @param {Compiler} compiler compiler
    * @returns {void}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

Moves option validation out of the constructor and onto `compiler.validate`, called from `compiler.hooks.validate`, so webpack owns when validation runs. `validate: false` now actually skips it — the constructor validated whatever the config said — and the schema is required lazily by the callback rather than at module load. Handing `compiler.validate` a pre-compiled check, so `schema-utils` and ajv are not loaded for valid options, is left to a follow-up PR.

Two fallbacks, both marked `TODO` to remove in the next major release:

- webpack calls `hooks.validate` before it applies `optimization.minimizer`, so that hook reaches this plugin only where it sits in `plugins`. `initialize` is tapped alongside it, behind a latch, so the minimizer placement is validated too.
- webpack before 5.106 has neither the hook nor `compiler.validate`, and validates with `schema-utils` directly.

Measured against a real webpack build, n=7 per arm, medians with ranges; retained heap read after forced GC:

| | before | after |
| --- | --- | --- |
| `require()` the plugin | 6.1 ms | 3.2 ms |
| default setup | 404 ms `[389-482]` | 419 ms `[390-446]` |
| default ajv modules / require.cache / retained heap | 126 / 770 / 25.5 MB | 126 / 770 / 25.5 MB |
| `validate: false` setup | 429 ms `[411-439]` | 298 ms `[292-328]` |
| `validate: false` ajv modules / require.cache / retained heap | 126 / 770 / 25.4 MB | 0 / 590 / 22.4 MB |

Requiring the plugin is faster because `options.json` is no longer parsed at module load. With validation on nothing else moves: the default-setup difference is smaller than the run-to-run spread and the ranges overlap, so it is not a result, and ajv loads either way until the pre-compiled check lands. The win is `validate: false`, where the ranges are disjoint.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

refactor

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/validate-options.test.js` drives real compilers throughout, and adds a case for the `optimization.minimizer` placement. No unit tests: the pre-5.106 `schema-utils` fallback is therefore not covered by any test, since the matrix only runs `webpack-version: latest`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Invalid options are still rejected with the same message; the error is now thrown when the compiler is created rather than when the plugin is constructed, and `validate: false` now suppresses it.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to rewire the validation and update the tests. The hook-ordering claim was verified empirically against webpack 5.109.2 rather than assumed: a probe plugin tapping both hooks reports `validate, initialize` for the `plugins` placement and `initialize` only for `optimization.minimizer`. The measurements above were taken by counting loaded modules and timing a real build across both arms; an earlier version of the harness attributed the constructor's cost to the wrong phase and was corrected before these numbers were taken. All changes were reviewed before committing.