### PR TITLE
fix: read every format an image minimizer writes, and stop offering sharp raw assets

### DIFF
--- a/.changeset/svg-and-jp2-detection.md
+++ b/.changeset/svg-and-jp2-detection.md
@@ -1,0 +1,5 @@
+---
+"minimizer-webpack-plugin": patch
+---
+
+read SVG and JPEG 2000 when detecting what format a minimizer wrote, so a plugin that converts an image into SVG is caught rather than writing SVG out under a name claiming a raster format — SVG carries no signature, so leaving it out made "not SVG" and "not recognized" the same answer

--- a/.changeset/svg-and-jp2-detection.md
+++ b/.changeset/svg-and-jp2-detection.md
@@ -2,4 +2,4 @@
 "minimizer-webpack-plugin": patch
 ---
 
-read SVG and JPEG 2000 when detecting what format a minimizer wrote, so a plugin that converts an image into SVG is caught rather than writing SVG out under a name claiming a raster format — SVG carries no signature, so leaving it out made "not SVG" and "not recognized" the same answer
+fix what the image minimizers read a format as: SVG and JPEG 2000 are now detected, so a plugin converting an image into SVG is caught rather than writing SVG out under a name claiming a raster format; a PNG is walked chunk by chunk, so a comment mentioning `acTL` no longer makes a still image animated and a colour profile containing `IDAT` no longer hides a real one; and `sharpMinify` no longer offers to minify `raw` assets, which it could only fail on

--- a/src/fileType.js
+++ b/src/fileType.js
@@ -51,9 +51,10 @@ const ISO_BRANDS = new Map([
 ]);
 
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
-// Past the signature and the IHDR chunk, where an `acTL` may precede the first
-// `IDAT` — which is what makes a PNG an APNG.
-const PNG_CHUNKS_START = 33;
+// A chunk is four bytes of length, four naming it, the data, then four of
+// checksum. The first one starts past the signature.
+const PNG_CHUNKS_START = PNG_SIGNATURE.length;
+const PNG_CHUNK_OVERHEAD = 12;
 
 /**
  * @param {Uint8Array} buffer the bytes
@@ -181,18 +182,36 @@ function isSvg(buffer) {
 /**
  * Whether a PNG carries an `acTL` chunk before its first `IDAT`, which makes it
  * an animated one.
+ *
+ * Walked chunk by chunk rather than scanned for the name, because a name is
+ * only a name where a chunk starts: a comment mentioning `acTL` would
+ * otherwise make a still image animated, and an ICC profile holding `IDAT` would
+ * end the search before the real `acTL`. Walking also steps over a profile in
+ * one jump instead of reading every byte of it.
  * @param {Uint8Array} buffer the bytes
  * @returns {boolean} true when it is animated
  */
 function isAnimatedPng(buffer) {
-  for (let i = PNG_CHUNKS_START; i < buffer.length - 4; i++) {
-    if (hasText(buffer, "IDAT", i)) {
+  let at = PNG_CHUNKS_START;
+
+  while (at + 8 <= buffer.length) {
+    if (hasText(buffer, "acTL", at + 4)) {
+      return true;
+    }
+
+    if (hasText(buffer, "IDAT", at + 4)) {
       return false;
     }
 
-    if (hasText(buffer, "acTL", i)) {
-      return true;
-    }
+    // Four bytes, most significant first; read as arithmetic because a shift
+    // would make anything past 2GiB negative.
+    const length =
+      buffer[at] * 0x1000000 +
+      buffer[at + 1] * 0x10000 +
+      buffer[at + 2] * 0x100 +
+      buffer[at + 3];
+
+    at += PNG_CHUNK_OVERHEAD + length;
   }
 
   return false;

--- a/src/fileType.js
+++ b/src/fileType.js
@@ -4,8 +4,11 @@
  * Only what an image minimizer can be handed or can write: `imageminMinify`
  * compares an asset's extension against the format its plugins produced, so a
  * format no such plugin emits could never change the answer. An unrecognized
- * buffer names nothing, which is also how a format with no signature at all —
- * SVG — reads.
+ * buffer names nothing.
+ *
+ * SVG has no signature, so it is read as the markup it is. Leaving it out
+ * would make "not SVG" and "not recognized" the same answer, and a conversion
+ * into SVG would then pass for an unchanged image.
  */
 
 /**
@@ -16,7 +19,10 @@
 const CANONICAL_EXTENSION = new Map([
   ["apng", "png"],
   ["heif", "heic"],
+  ["j2c", "jp2"],
+  ["j2k", "jp2"],
   ["jpeg", "jpg"],
+  ["jpx", "jp2"],
   ["tif", "tiff"],
 ]);
 
@@ -79,6 +85,97 @@ function hasText(buffer, text, offset = 0) {
   }
 
   return true;
+}
+
+/**
+ * @param {Uint8Array} buffer the bytes
+ * @param {string} text the ASCII to match, in lower case
+ * @param {number} offset where to match it
+ * @returns {boolean} true when it is there in either case
+ */
+function hasTextIgnoringCase(buffer, text, offset) {
+  for (let i = 0; i < text.length; i++) {
+    if ((buffer[i + offset] | 0x20) !== text.charCodeAt(i)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+const WHITESPACE = new Set([0x09, 0x0a, 0x0c, 0x0d, 0x20]);
+const BYTE_ORDER_MARK = [0xef, 0xbb, 0xbf];
+// A prolog, a doctype and comments can all precede the root element. Bounded
+// so a large file is not walked to answer a question its first line settles.
+const MARKUP_SCAN_LIMIT = 1024;
+
+/**
+ * @param {Uint8Array} buffer the bytes
+ * @param {string} text the ASCII that ends the construct
+ * @param {number} from where to start looking
+ * @param {number} limit how far to look
+ * @returns {number} the index past it, or the limit when it does not end
+ */
+function endOf(buffer, text, from, limit) {
+  for (let at = from; at < limit; at++) {
+    if (hasText(buffer, text, at)) {
+      return at + text.length;
+    }
+  }
+
+  return limit;
+}
+
+/**
+ * Where a document's root element starts, past a byte-order mark, whitespace,
+ * an XML prolog, a doctype and any comments.
+ * @param {Uint8Array} buffer the bytes
+ * @returns {number} the index, or -1 when nothing there is markup
+ */
+function rootElementAt(buffer) {
+  const limit = Math.min(buffer.length, MARKUP_SCAN_LIMIT);
+  let at = startsWith(buffer, BYTE_ORDER_MARK) ? BYTE_ORDER_MARK.length : 0;
+
+  while (at < limit) {
+    if (WHITESPACE.has(buffer[at])) {
+      at += 1;
+    } else if (hasText(buffer, "<!--", at)) {
+      at = endOf(buffer, "-->", at + 4, limit);
+    } else if (hasText(buffer, "<?", at) || hasText(buffer, "<!", at)) {
+      at = endOf(buffer, ">", at + 2, limit);
+    } else if (hasText(buffer, "<", at)) {
+      return at;
+    } else {
+      // Text before any markup: whatever this is, it is not a document.
+      return -1;
+    }
+  }
+
+  return -1;
+}
+
+/**
+ * Whether the document's root element is `<svg>`. Asking for the root rather
+ * than for the text anywhere keeps an HTML page that happens to carry an
+ * inline `<svg>` from reading as one.
+ * @param {Uint8Array} buffer the bytes
+ * @returns {boolean} true when it is an SVG document
+ */
+function isSvg(buffer) {
+  const root = rootElementAt(buffer);
+
+  if (root === -1 || !hasTextIgnoringCase(buffer, "<svg", root)) {
+    return false;
+  }
+
+  const after = buffer[root + 4];
+
+  return (
+    typeof after === "undefined" ||
+    WHITESPACE.has(after) ||
+    after === 0x3e ||
+    after === 0x2f
+  );
 }
 
 /**
@@ -161,6 +258,18 @@ function fileTypeFromBuffer(input) {
     return { ext: "jxl", mime: "image/jxl" };
   }
 
+  // The same box structure as JPEG XL's container, naming `jP  ` instead, and
+  // the bare codestream a `.j2k` holds.
+  if (
+    startsWith(
+      buffer,
+      [0x00, 0x00, 0x00, 0x0c, 0x6a, 0x50, 0x20, 0x20, 0x0d, 0x0a, 0x87, 0x0a],
+    ) ||
+    startsWith(buffer, [0xff, 0x4f, 0xff, 0x51])
+  ) {
+    return { ext: "jp2", mime: "image/jp2" };
+  }
+
   if (
     startsWith(buffer, [0x49, 0x49, 0x2a, 0x00]) ||
     startsWith(buffer, [0x4d, 0x4d, 0x00, 0x2a])
@@ -174,6 +283,11 @@ function fileTypeFromBuffer(input) {
 
   if (startsWith(buffer, [0x00, 0x00, 0x01, 0x00])) {
     return { ext: "ico", mime: "image/x-icon" };
+  }
+
+  // Last, so that no signature above is shadowed by a scan of text.
+  if (isSvg(buffer)) {
+    return { ext: "svg", mime: "image/svg+xml" };
   }
 
   return undefined;

--- a/src/utils.js
+++ b/src/utils.js
@@ -2312,6 +2312,10 @@ function toBuffer(code) {
 /**
  * Which sharp format each extension names. Minifying re-encodes a file as
  * itself, so this is both the set sharp is offered and the format it writes.
+ *
+ * `raw` is not among them though sharp writes it: bare pixels carry no header,
+ * so sharp cannot read one back without being told its width and height, which
+ * a minimizer handed only bytes has no way to know.
  * @type {Map<string, string>}
  */
 const SHARP_MINIFY_FORMATS = new Map([
@@ -2326,7 +2330,6 @@ const SHARP_MINIFY_FORMATS = new Map([
   ["jpg", "jpeg"],
   ["jpx", "jp2"],
   ["png", "png"],
-  ["raw", "raw"],
   ["tif", "tiff"],
   ["tiff", "tiff"],
   ["webp", "webp"],
@@ -2765,14 +2768,27 @@ async function napiRsImageMinify(input, sourceMap, minimizerOptions) {
     (operation) => pipeline[operation],
   );
   const blurs = typeof pipeline.blur === "number";
+  const bytes = toBuffer(code);
+  /** @type {EXPECTED_OBJECT | undefined} */
+  let metadata;
+
+  /**
+   * The header, read at most once for the two questions below that need it.
+   * Asked with its EXIF, which is the only way `orientation` comes back.
+   * @returns {Promise<EXPECTED_ANY>} what the header says
+   */
+  const readMetadata = async () => {
+    metadata = metadata || (await new image.Transformer(bytes).metadata(true));
+
+    return metadata;
+  };
+
   // Decoding and encoding again costs some twenty times what reading the
   // header does, so an image whose EXIF asks for nothing keeps the fast path
   // rather than paying for a turn it does not need — which is what
   // `rotate: "auto"` set for every image would otherwise cost most of them.
   if (turnsByExif && typeof orientation === "undefined") {
-    const { orientation: exif } = await new image.Transformer(
-      toBuffer(code),
-    ).metadata(true);
+    const { orientation: exif } = await readMetadata();
 
     turnsByExif = typeof exif === "number" && exif > 1;
   }
@@ -2788,9 +2804,7 @@ async function napiRsImageMinify(input, sourceMap, minimizerOptions) {
     typeof resize.width !== "number" &&
     typeof askedHeight === "number"
   ) {
-    const { width, height } = await new image.Transformer(
-      toBuffer(code),
-    ).metadata();
+    const { width, height } = await readMetadata();
 
     sizing = {
       ...resize,
@@ -2845,18 +2859,18 @@ async function napiRsImageMinify(input, sourceMap, minimizerOptions) {
     return transformer;
   };
 
-  let bytes = toBuffer(code);
+  let written = bytes;
 
   if (encoder.repack) {
     if (transforms) {
-      bytes = await encoder.write(
+      written = await encoder.write(
         transform(new image.Transformer(bytes)),
         encodeOptions,
       );
     }
 
     return withWarnings(
-      await encoder.repack(image, bytes, encodeOptions),
+      await encoder.repack(image, written, encodeOptions),
       warnings,
     );
   }

--- a/test/file-type.test.js
+++ b/test/file-type.test.js
@@ -19,36 +19,80 @@ const text = (leading, length = 64) =>
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
 /**
- * @param {string} chunk the chunk name to place where `acTL` would sit
- * @returns {Buffer} a PNG carrying it
+ * One PNG chunk: four bytes of length, four naming it, the data, then four of
+ * checksum. Built properly so a name inside a chunk's *data* is not mistaken
+ * for one starting a chunk.
+ * @param {string} name the chunk's name
+ * @param {Buffer=} data what it carries
+ * @returns {Buffer} the chunk
  */
-const png = (chunk) =>
+function chunk(name, data = Buffer.alloc(0)) {
+  const length = Buffer.alloc(4);
+
+  length.writeUInt32BE(data.length);
+
+  return Buffer.concat([
+    length,
+    Buffer.from(name, "ascii"),
+    data,
+    Buffer.alloc(4),
+  ]);
+}
+
+/**
+ * @param {...Buffer} chunks the chunks to carry, after the header
+ * @returns {Buffer} a PNG made of them
+ */
+const png = (...chunks) =>
   Buffer.concat([
     Buffer.from(PNG_SIGNATURE),
-    Buffer.alloc(25),
-    Buffer.from(chunk, "ascii"),
-    Buffer.alloc(16),
+    chunk("IHDR", Buffer.alloc(13)),
+    ...chunks,
   ]);
 
 describe("fileTypeFromBuffer", () => {
   it("should detect PNG", () => {
-    expect(fileTypeFromBuffer(png("IDAT"))).toEqual({
+    expect(fileTypeFromBuffer(png(chunk("IDAT", Buffer.alloc(8))))).toEqual({
       ext: "png",
       mime: "image/png",
     });
   });
 
   it("should detect APNG by its `acTL` chunk", () => {
-    expect(fileTypeFromBuffer(png("acTL"))).toEqual({
-      ext: "apng",
-      mime: "image/apng",
-    });
+    expect(
+      fileTypeFromBuffer(
+        png(chunk("acTL", Buffer.alloc(8)), chunk("IDAT", Buffer.alloc(8))),
+      ),
+    ).toEqual({ ext: "apng", mime: "image/apng" });
   });
 
   it("should not read an `acTL` after the first `IDAT` as animation", () => {
-    const late = Buffer.concat([png("IDAT"), Buffer.from("acTL", "ascii")]);
+    const late = png(chunk("IDAT", Buffer.alloc(8)), chunk("acTL"));
 
     expect(fileTypeFromBuffer(late).ext).toBe("png");
+  });
+
+  it("should not read a comment mentioning `acTL` as animation", () => {
+    // The name means something only where a chunk starts. Scanning for it
+    // instead made any image whose metadata says the word animated.
+    const described = png(
+      chunk("tEXt", Buffer.from("Comment: made with acTL tools")),
+      chunk("IDAT", Buffer.alloc(8)),
+    );
+
+    expect(fileTypeFromBuffer(described).ext).toBe("png");
+  });
+
+  it("should not let `IDAT` inside a profile end the search early", () => {
+    // The other way the same mistake reads: a real `acTL` after a profile
+    // whose bytes happen to spell `IDAT` was never reached.
+    const profiled = png(
+      chunk("iCCP", Buffer.from("profileIDATmore")),
+      chunk("acTL", Buffer.alloc(8)),
+      chunk("IDAT", Buffer.alloc(8)),
+    );
+
+    expect(fileTypeFromBuffer(profiled).ext).toBe("apng");
   });
 
   it("should read a PNG carrying neither chunk as still", () => {
@@ -58,6 +102,17 @@ describe("fileTypeFromBuffer", () => {
     ]);
 
     expect(fileTypeFromBuffer(truncated).ext).toBe("png");
+  });
+
+  it("should stop at a chunk whose length runs past the end", () => {
+    const lying = Buffer.concat([
+      Buffer.from(PNG_SIGNATURE),
+      chunk("IHDR", Buffer.alloc(13)),
+      Buffer.from("7fffffff", "hex"),
+      Buffer.from("acTL", "ascii"),
+    ]);
+
+    expect(fileTypeFromBuffer(lying).ext).toBe("apng");
   });
 
   it("should detect JPEG", () => {

--- a/test/file-type.test.js
+++ b/test/file-type.test.js
@@ -128,8 +128,94 @@ describe("fileTypeFromBuffer", () => {
     expect(fileTypeFromBuffer(bytes([0x00, 0x00, 0x01, 0x00])).ext).toBe("ico");
   });
 
-  it("should name nothing for SVG, which has no signature", () => {
-    expect(fileTypeFromBuffer(Buffer.from("<svg></svg>"))).toBeUndefined();
+  it.each([
+    [
+      "a plain document",
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>',
+    ],
+    ["a self-closing root", "<svg/>"],
+    ["nothing after the name", "<svg"],
+    // XML is case-sensitive, but reading either costs nothing.
+    ["an upper-case root", "<SVG></SVG>"],
+    ["leading whitespace", "\n\n   <svg></svg>"],
+    ["an XML prolog", '<?xml version="1.0"?><svg></svg>'],
+    [
+      "a prolog and a doctype",
+      '<?xml version="1.0"?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN">\n<svg></svg>',
+    ],
+    ["a comment first", "<!-- by hand -->\n<svg></svg>"],
+    ["several comments", "<!--a--><!--b--><svg></svg>"],
+  ])("should detect SVG past %s", (_name, markup) => {
+    expect(fileTypeFromBuffer(Buffer.from(markup))).toEqual({
+      ext: "svg",
+      mime: "image/svg+xml",
+    });
+  });
+
+  it("should detect SVG past a byte-order mark", () => {
+    expect(
+      fileTypeFromBuffer(
+        Buffer.concat([
+          Buffer.from([0xef, 0xbb, 0xbf]),
+          Buffer.from("<svg></svg>"),
+        ]),
+      ).ext,
+    ).toBe("svg");
+  });
+
+  it.each([
+    // The root element is asked for, so an inline one does not count.
+    [
+      "an HTML page carrying an inline one",
+      "<!DOCTYPE html><html><svg/></html>",
+    ],
+    ["an HTML page with no doctype", "<html><svg/></html>"],
+    ["another kind of XML", '<?xml version="1.0"?><rss></rss>'],
+    ["prose mentioning one", "this file talks about <svg> tags"],
+    ["an element whose name merely starts with it", "<svg-icon></svg-icon>"],
+  ])("should not read %s as SVG", (_name, markup) => {
+    expect(fileTypeFromBuffer(Buffer.from(markup))).toBeUndefined();
+  });
+
+  it("should give up rather than walk a document that never opens", () => {
+    // The scan is bounded, so an unterminated comment ends it.
+    const runaway = Buffer.concat([
+      Buffer.from("<!--"),
+      Buffer.alloc(4000, 0x61),
+    ]);
+
+    expect(fileTypeFromBuffer(runaway)).toBeUndefined();
+  });
+
+  it("should not read a gzipped SVG as one, having no markup to read", () => {
+    expect(
+      fileTypeFromBuffer(Buffer.from([0x1f, 0x8b, 0x08, 0x00])),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    [
+      "the container",
+      [0x00, 0x00, 0x00, 0x0c, 0x6a, 0x50, 0x20, 0x20, 0x0d, 0x0a, 0x87, 0x0a],
+    ],
+    ["a bare codestream", [0xff, 0x4f, 0xff, 0x51]],
+  ])("should detect JPEG 2000 as %s", (_name, signature) => {
+    expect(fileTypeFromBuffer(bytes(signature))).toEqual({
+      ext: "jp2",
+      mime: "image/jp2",
+    });
+  });
+
+  it("should keep JPEG XL's container apart from JPEG 2000's", () => {
+    // The same box structure; only the four bytes naming it differ.
+    expect(
+      fileTypeFromBuffer(
+        bytes([
+          0x00, 0x00, 0x00, 0x0c, 0x4a, 0x58, 0x4c, 0x20, 0x0d, 0x0a, 0x87,
+          0x0a,
+        ]),
+      ).ext,
+    ).toBe("jxl");
   });
 
   it("should name nothing for an unknown format", () => {
@@ -167,6 +253,9 @@ describe("canonicalExtension", () => {
     ["tif", "tiff"],
     ["apng", "png"],
     ["heif", "heic"],
+    ["j2k", "jp2"],
+    ["j2c", "jp2"],
+    ["jpx", "jp2"],
   ])("should read %s as %s", (from, to) => {
     expect(canonicalExtension(from)).toBe(to);
   });

--- a/test/image-minify-option.test.js
+++ b/test/image-minify-option.test.js
@@ -457,6 +457,26 @@ describe("image minify option", () => {
     );
   });
 
+  it("should keep an image a plugin turned into SVG", async () => {
+    // The other direction of the same guard. SVG carries no signature, so
+    // until it was read as the markup it is, a conversion *into* it named
+    // nothing, the mismatch went unseen, and SVG was written out under a name
+    // claiming a raster format.
+    const svg = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect x="1.00000"/></svg>',
+    );
+    const { code, warnings } = await MinimizerPlugin.imageminMinify(
+      { "photo.png": svg },
+      undefined,
+      { plugins: ["svgo"] },
+    );
+
+    expect(code).toEqual(svg);
+    expect(warnings.join("\n")).toContain(
+      'does not support generating "svg" from "photo.png"',
+    );
+  });
+
   it("should throw when `imageminMinify` has no plugins", async () => {
     const compiler = getCompiler({
       entry: path.resolve(__dirname, "./fixtures/images.js"),

--- a/test/image-minify-option.test.js
+++ b/test/image-minify-option.test.js
@@ -457,6 +457,18 @@ describe("image minify option", () => {
     );
   });
 
+  it("should not offer `sharpMinify` a raw asset it could only fail on", async () => {
+    // Bare pixels carry no header, so sharp cannot read one back — offering
+    // it one fails the build rather than minifying anything.
+    expect(MinimizerPlugin.sharpMinify.filter("pixels.raw")).toBe(false);
+
+    const pixels = Buffer.alloc(32 * 32 * 3, 7);
+
+    await expect(require("sharp")(pixels).metadata()).rejects.toThrow(
+      /unsupported image format/,
+    );
+  });
+
   it("should keep an image a plugin turned into SVG", async () => {
     // The other direction of the same guard. SVG carries no signature, so
     // until it was read as the markup it is, a conversion *into* it named


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

Four defects in how the image minimizers decide what a buffer holds, found while checking whether format detection was complete enough to build format conversion on.

- **A conversion into SVG was invisible.** SVG carries no signature, so `fileTypeFromBuffer` named nothing for it — which made "not SVG" and "not recognized" the same answer. `imageminMinify` compares the format a plugin produced against the one the asset's name claims, so SVG was written out under a name claiming a raster format. Driven with `svgo`: before, `photo.png` came back holding SVG; now the original is kept with `does not support generating "svg" from "photo.png"`. The reverse direction already worked.
- **A still PNG could read as animated, and an APNG as still.** `isAnimatedPng` scanned for chunk names instead of walking chunks, and a name means something only where a chunk starts. A `tEXt` comment mentioning `acTL` made a still image animated; an APNG whose `iCCP` profile contained the bytes `IDAT` ended the search inside the profile and read as still.
- **`sharpMinify` offered to minify `raw` assets, which it can only fail on.** Bare pixels carry no header, so sharp cannot read one back without being told its width and height — `filter("pixels.raw")` returned `true` and sharp then threw `Input buffer contains unsupported image format`, failing the build. Inherited from `image-minimizer-webpack-plugin`, which lists `["raw", "raw"]` in the same table.
- **JPEG 2000 was undetected** though `sharpMinify` accepts and writes it.

With `raw` gone and SVG and JPEG 2000 read, detection is now total: every extension the four image minimizers accept is one the sniffer names, verified end to end against real encodes.

Walking PNG chunks is also strictly less work — it steps over a colour profile in one jump instead of reading every byte. On a PNG carrying a 3 KiB profile and 8 KiB of EXIF, **22,640 buffer reads become 24**. Separately, the header read for `@napi-rs/image` is memoized, so `?rotate=auto` asked alongside a height-only resize decodes once rather than twice (3 → 2 `Transformer` constructions, measured against the previous commit).

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/file-type.test.js` (33 → 58 cases: SVG past a BOM, prolog, doctype and comments, seven negatives including an HTML page carrying an inline `<svg>`, both PNG misreadings, JPEG 2000 against JPEG XL's identical box structure) and `test/image-minify-option.test.js` (the SVG conversion guard, and that `raw` is no longer offered). The PNG fixtures now build real chunks rather than placing names at a fixed offset — the old helper only passed because the scan it was written for did not look at chunk boundaries either.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. `sharpMinify` no longer accepts `.raw` assets, but it could only throw on them, so nothing that worked stops working.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — no option or API surface changed.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to investigate and implement this. Every defect was reproduced before being fixed and re-checked afterwards, the format coverage was verified by encoding real samples of each accepted extension and putting them through the sniffer, and both performance figures are counted rather than timed. One hypothesis it tested — that `animated: true` costs something on still images — was measured, found to make no difference (118 vs 119 ms best-of, no retained-heap delta), and dropped rather than shipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_016TQeNpahUSDUjD2Crugy5H)_