### PR TITLE
fix: end worker pool after processing failures

### DIFF
--- a/.changeset/worker-cleanup.md
+++ b/.changeset/worker-cleanup.md
@@ -1,0 +1,5 @@
+---
+"minimizer-webpack-plugin": patch
+---
+
+always end the parallel worker pool when processing a minimizer result fails

--- a/src/index.js
+++ b/src/index.js
@@ -931,10 +931,12 @@ class TerserPlugin {
               optimizeOptions.availableNumberOfCores,
             )
           : scheduledTasks.length;
-    await throttleAll(limit, scheduledTasks);
-
-    if (initializedWorker) {
-      await initializedWorker.end();
+    try {
+      await throttleAll(limit, scheduledTasks);
+    } finally {
+      if (initializedWorker) {
+        await initializedWorker.end();
+      }
     }
 
     /** @typedef {{ source: import("webpack").sources.Source, commentsFilename: string, from: string }} ExtractedCommentsInfoWithFrom */

--- a/test/parallel-option.test.js
+++ b/test/parallel-option.test.js
@@ -29,6 +29,7 @@ jest.mock("os", () => {
 // Based on https://github.com/facebook/jest/blob/edde20f75665c2b1e3c8937f758902b5cf28a7b4/packages/jest-runner/src/__tests__/test_runner.test.js
 let workerTransform;
 let workerEnd;
+let mockWorkerTransformImplementation;
 
 const ENABLE_WORKER_THREADS =
   typeof process.env.ENABLE_WORKER_THREADS !== "undefined"
@@ -38,7 +39,9 @@ const ENABLE_WORKER_THREADS =
 jest.mock("jest-worker", () => ({
   Worker: jest.fn().mockImplementation((workerPath) => ({
     transform: (workerTransform = jest.fn((data) =>
-      require(workerPath).transform(data),
+      mockWorkerTransformImplementation
+        ? mockWorkerTransformImplementation(data)
+        : require(workerPath).transform(data),
     )),
     end: (workerEnd = jest.fn()),
     getStderr: jest.fn(),
@@ -61,6 +64,7 @@ describe("parallel option", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockWorkerTransformImplementation = undefined;
 
     compiler = getCompiler({
       entry: {
@@ -122,6 +126,19 @@ describe("parallel option", () => {
     expect(readsAssets(compiler, stats)).toMatchSnapshot("assets");
     expect(getErrors(stats)).toMatchSnapshot("errors");
     expect(getWarnings(stats)).toMatchSnapshot("warnings");
+  });
+
+  it("should end the worker when result processing fails", async () => {
+    mockWorkerTransformImplementation = async () => ({
+      get code() {
+        throw new Error("result processing failed");
+      },
+    });
+
+    new MinimizerPlugin().apply(compiler);
+
+    await expect(compile(compiler)).rejects.toThrow("result processing failed");
+    expect(workerEnd).toHaveBeenCalledTimes(1);
   });
 
   it('should match snapshot for the "undefined" value', async () => {


### PR DESCRIPTION
## What does this PR do?

Ensures the parallel `jest-worker` pool is ended when processing a minimizer result throws.

`optimize()` previously awaited `throttleAll()` before calling `worker.end()`. Any rejection after the pool had been initialized skipped cleanup and left its workers running. The task execution is now wrapped in `try/finally`, preserving the existing successful path while guaranteeing cleanup.

This PR contains only this lifecycle fix and its regression test.

## Testing

- Added a regression that makes post-worker result processing throw and verifies `worker.end()` is called.
- On unmodified `main`, the regression fails with 0 cleanup calls.
- Focused parallel suite: 10 tests / 27 snapshots passed.
- Full `npm test`: lint, formatting, spelling, type checks, serializer check, 20 suites / 525 tests / 822 snapshots and coverage passed.
- `npm run build`: passed.
- `git diff --check`: passed.
