### PR TITLE
fix: preserve explicit module false option

### DIFF
--- a/.changeset/explicit-module-option.md
+++ b/.changeset/explicit-module-option.md
@@ -1,0 +1,5 @@
+---
+"minimizer-webpack-plugin": patch
+---
+
+preserve an explicit `module: false` minimizer option when webpack identifies an asset as a module

--- a/src/minify.js
+++ b/src/minify.js
@@ -477,7 +477,10 @@ async function minify(options) {
       /** @type {import("./index.js").MinimizerOptions<T>} */
       ({
         ...baseOptions,
-        module: baseOptions.module || module,
+        module:
+          typeof baseOptions.module === "undefined"
+            ? module
+            : baseOptions.module,
         ecma: baseOptions.ecma || ecma,
         // Only for a minimizer that says it reads the option: every other one is
         // handed its own options untouched, so nothing sees a key it does not know.

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3,6 +3,23 @@ import serialize from "../src/serialize-javascript.js";
 import { terserMinify } from "../src/utils.js";
 
 describe("worker", () => {
+  it("preserves an explicit false module option", async () => {
+    const options = {
+      name: "test.mjs",
+      input: "export default 1;",
+      module: true,
+      minimizer: {
+        implementation: async (...args) => ({
+          code: String(args[2].module),
+        }),
+        options: { module: false },
+      },
+    };
+    const workerResult = await transform(serialize(options));
+
+    expect(workerResult.code).toBe("false");
+  });
+
   it('should match snapshot when options.extractComments is "false"', async () => {
     const options = {
       name: "test1.js",


### PR DESCRIPTION
## What does this PR do?

Preserves an explicit `minimizerOptions.module: false` value when webpack marks the asset as a JavaScript module.

The options overlay currently uses `baseOptions.module || module`, so an explicit `false` is replaced by webpack's inferred `true`. The new undefined check keeps the inferred value as the default while allowing users to override it with `false`.

This PR contains only this option-precedence fix and its regression test.

## Testing

- Added a worker-boundary regression that passes inferred `module: true` with explicit `module: false` and records the option received by the minimizer.
- On unmodified `main`, the regression fails with `"true"`; with this change it receives `"false"`.
- Focused worker suite: 22 tests / 21 snapshots passed.
- Full `npm test`: lint, formatting, spelling, type checks, serializer check, 20 suites / 525 tests / 822 snapshots and coverage passed.
- `npm run build`: passed.
- `git diff --check`: passed.
