### PR TITLE
fix: preserve empty source map content

### DIFF
--- a/.changeset/empty-source-content.md
+++ b/.changeset/empty-source-content.md
@@ -1,0 +1,5 @@
+---
+"minimizer-webpack-plugin": patch
+---
+
+preserve empty `sourcesContent` entries when composing source maps across minimizers

--- a/src/minify.js
+++ b/src/minify.js
@@ -144,7 +144,7 @@ function composeSourceMaps(currentMap, prevMap, name) {
 
   /**
    * @param {string | null | undefined} source source identifier
-   * @param {string | undefined} content source content (when available)
+   * @param {string | null | undefined} content source content (when available)
    * @returns {number} index assigned in the composed map
    */
   const getSourceIdx = (source, content) => {
@@ -234,7 +234,7 @@ function composeSourceMaps(currentMap, prevMap, name) {
           continue;
         }
 
-        const content = sourceContentFor(previous, orig.source) || undefined;
+        const content = sourceContentFor(previous, orig.source);
         const newSrcIdx = getSourceIdx(orig.source, content);
         const finalName =
           typeof orig.name === "string" && orig.name ? orig.name : segName;
@@ -251,7 +251,7 @@ function composeSourceMaps(currentMap, prevMap, name) {
           newSegments.push([seg[0], newSrcIdx, orig.line - 1, orig.column]);
         }
       } else {
-        const content = sourceContentFor(current, sourceName) || undefined;
+        const content = sourceContentFor(current, sourceName);
         const newSrcIdx = getSourceIdx(sourceName, content);
 
         if (typeof segName === "string") {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3,6 +3,34 @@ import serialize from "../src/serialize-javascript.js";
 import { terserMinify } from "../src/utils.js";
 
 describe("worker", () => {
+  it("preserves empty source content when composing source maps", async () => {
+    const options = {
+      name: "bundle.js",
+      input: "x",
+      inputSourceMap: {
+        version: 3,
+        sources: ["empty.js"],
+        sourcesContent: [""],
+        names: [],
+        mappings: "AAAA",
+      },
+      minimizer: {
+        implementation: async (input) => ({
+          code: Object.values(input)[0],
+          map: {
+            version: 3,
+            sources: ["bundle.js"],
+            names: [],
+            mappings: "AAAA",
+          },
+        }),
+      },
+    };
+    const workerResult = await transform(serialize(options));
+
+    expect(workerResult.map.sourcesContent).toEqual([""]);
+  });
+
   it('should match snapshot when options.extractComments is "false"', async () => {
     const options = {
       name: "test1.js",


### PR DESCRIPTION
## What does this PR do?

Preserves valid empty-string `sourcesContent` entries while composing source maps across minimizer steps.

The composition code currently converts `sourceContentFor(...)` through `|| undefined`. An empty source file therefore loses its `""` content, and when it is the only source the composed map omits `sourcesContent` entirely. Passing the nullable result through directly retains empty strings while keeping the existing missing-content behavior.

This PR contains only this source-map metadata fix and its regression test.

## Testing

- Added a worker-boundary regression that composes a generated map with an input map containing `sourcesContent: [""]`.
- On unmodified `main`, the composed map returns `sourcesContent: undefined`; with this change it preserves `[""]`.
- Focused worker suite: 22 tests / 21 snapshots passed.
- Full `npm test`: lint, formatting, spelling, type checks, serializer check, 20 suites / 525 tests / 822 snapshots and coverage passed.
- `npm run build`: passed.
- `git diff --check`: passed.
