### PR TITLE
test: cover every language a document or a stylesheet embeds

### DIFF
--- a/test/__snapshots__/embedded-source.test.js.snap
+++ b/test/__snapshots__/embedded-source.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`embedded source every language a host offers matches snapshot: assets 1`] = `
+{
+  "every-language.css": ".svg{background:url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'> <rect id='svgPayload' /> </svg>")}.css{background:url(data:text/css,.cssPayload{color:%230f0})}.html{background:url(data:text/html,<p\\ id=htmlPayload>hi)}.json{background:url('data:application/json,{"jsonPayload":1}')}.js{background:url(data:text/javascript,var\\ jsPayload=1;)}",
+  "every-language.html": "<!doctype html><html lang=en><head><title>x</title><style>.styleElement{color:#0f0}</style><script>var scriptElement=1;function f(){return scriptElement}</script><script type=application/json>{"jsonElement":1}</script></head><body>
+<p style=color:#00f>hi</p>
+<svg xmlns=http://www.w3.org/2000/svg> <rect id=svgSubtree /> </svg>
+<iframe srcdoc="<p id=srcdocElement>hi"></iframe>
+
+</body></html>",
+}
+`;

--- a/test/embedded-source.test.js
+++ b/test/embedded-source.test.js
@@ -645,4 +645,229 @@ describe("embedded source", () => {
       );
     });
   });
+
+  describe("every language a host offers", () => {
+    /** @type {{ language: string, code: string }[]} */
+    const reached = [];
+
+    /**
+     * Wraps a minimizer so a case can say that *this plugin* reached a body.
+     * The emitted bytes alone cannot: webpack minifies an inline `<style>` and
+     * a JSON `<script>` with its own minifiers either way, so for those two the
+     * output is the same whether or not anything here ran.
+     * @param {string} language the language it minifies
+     * @param {EXPECTED_ANY} implementation the minimizer to record around
+     * @returns {EXPECTED_ANY} the recording minimizer
+     */
+    function recording(language, implementation) {
+      /**
+       * @param {{ [file: string]: string }} input a single `{ filename: code }` entry
+       * @param {EXPECTED_ANY} sourceMap the source map, when there is one
+       * @param {EXPECTED_ANY} minimizerOptions minimizer options
+       * @param {EXPECTED_ANY} extractComments extract comments option
+       * @returns {EXPECTED_ANY} what the wrapped minimizer answered
+       */
+      const wrapped = (input, sourceMap, minimizerOptions, extractComments) => {
+        const [[, code]] = Object.entries(input);
+
+        reached.push({ language, code });
+
+        return implementation(
+          input,
+          sourceMap,
+          minimizerOptions,
+          extractComments,
+        );
+      };
+
+      wrapped.getTypes = () => [language];
+      wrapped.getMinimizerVersion = () => "1.0.0";
+      // Recording is what these are for, and a worker would do it in another
+      // process.
+      wrapped.supportsWorker = () => false;
+      wrapped.supportsWorkerThreads = () => false;
+      wrapped.filter = implementation.filter;
+
+      if (implementation.getEmbeddedTypes) {
+        wrapped.getEmbeddedTypes = implementation.getEmbeddedTypes;
+      }
+
+      return wrapped;
+    }
+
+    /**
+     * @param {{ [file: string]: string }} input a single `{ filename: code }` entry
+     * @returns {{ code: string }} the JSON, re-encoded without its whitespace
+     */
+    function jsonMinify(input) {
+      const [[, code]] = Object.entries(input);
+
+      return { code: JSON.stringify(JSON.parse(code)) };
+    }
+
+    jsonMinify.filter = (name) => /\.json(\?.*)?$/i.test(name);
+
+    // The document and the stylesheet name the same five languages between
+    // them, so one plugin carrying a minimizer for each covers both hosts.
+    const CASES = [
+      {
+        host: "every-language.html",
+        language: "css",
+        where: "a <style> element",
+        from: "  .styleElement { color : #00ff00 }  ",
+        to: "<style>.styleElement{color:#0f0}</style>",
+        gone: "#00ff00",
+      },
+      {
+        host: "every-language.html",
+        language: "css",
+        where: "a style attribute",
+        from: "  color : #0000ff ;  ",
+        to: "<p style=color:#00f>hi</p>",
+        gone: "#0000ff",
+      },
+      {
+        host: "every-language.html",
+        language: "javascript",
+        where: "a <script> element",
+        from: "  var  scriptElement  =  1 ;  function  f ( ) { return  scriptElement }  ",
+        to: "<script>var scriptElement=1;function f(){return scriptElement}</script>",
+        gone: "var  scriptElement",
+      },
+      {
+        host: "every-language.html",
+        language: "json",
+        where: "a JSON <script> element",
+        from: '  { "jsonElement" :  1 }  ',
+        to: '<script type=application/json>{"jsonElement":1}</script>',
+        gone: '{ "jsonElement"',
+      },
+      {
+        host: "every-language.html",
+        language: "svg",
+        where: "an <svg> subtree",
+        from: "<svg xmlns=http://www.w3.org/2000/svg>   <rect id=svgSubtree />   </svg>",
+        to: "<svg xmlns=http://www.w3.org/2000/svg> <rect id=svgSubtree /> </svg>",
+        gone: ">   <rect",
+      },
+      {
+        host: "every-language.html",
+        language: "html",
+        where: "an <iframe srcdoc>",
+        from: '<p   id="srcdocElement"   >hi</p>',
+        to: '<iframe srcdoc="<p id=srcdocElement>hi">',
+        gone: "<p   id",
+      },
+      {
+        host: "every-language.css",
+        language: "svg",
+        where: "a url() data: payload",
+        from: "<svg xmlns='http://www.w3.org/2000/svg'>   <rect  id='svgPayload'  />   </svg>",
+        to: "url(\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'> <rect id='svgPayload' /> </svg>\")",
+        gone: "<rect  id='svgPayload'",
+      },
+      {
+        host: "every-language.css",
+        language: "css",
+        where: "a url() data: payload",
+        from: ".cssPayload  {  color : #00ff00  }",
+        to: "url(data:text/css,.cssPayload{color:%230f0})",
+        gone: ".cssPayload  {",
+      },
+      {
+        host: "every-language.css",
+        language: "html",
+        where: "a url() data: payload",
+        from: "<p   id='htmlPayload'   >hi</p>",
+        to: "url(data:text/html,<p\\ id=htmlPayload>hi)",
+        gone: "<p   id='htmlPayload'",
+      },
+      {
+        host: "every-language.css",
+        language: "json",
+        where: "a url() data: payload",
+        from: '{ "jsonPayload" :  1 }',
+        to: "url('data:application/json,{\"jsonPayload\":1}')",
+        gone: '{ \\"jsonPayload\\"',
+      },
+      {
+        host: "every-language.css",
+        language: "javascript",
+        where: "a url() data: payload",
+        from: "var  jsPayload  =  1 ;",
+        to: "url(data:text/javascript,var\\ jsPayload=1;)",
+        gone: "var  jsPayload",
+      },
+    ];
+
+    /** @type {{ [file: string]: string }} */
+    const assets = {};
+    /** @type {string[]} */
+    let errors;
+
+    beforeAll(async () => {
+      const compiler = getCompiler({
+        entry: fixture("entry-every-language.js"),
+        target: "node",
+        output: {
+          path: path.resolve(__dirname, "helpers/dist"),
+          filename: "[name].js",
+          assetModuleFilename: "[name][ext]",
+        },
+        module: {
+          rules: [{ test: /\.(?:html|css)$/, type: "asset/resource" }],
+        },
+      });
+
+      defaultPlugin({
+        test: /\.(?:[cm]?js|css|html|svg|json)(\?.*)?$/i,
+        minify: [
+          recording("javascript", MinimizerPlugin.terserMinify),
+          recording("css", cssMinify),
+          recording("html", htmlMinify),
+          recording("svg", svgMinify),
+          recording("json", jsonMinify),
+        ],
+        minimizerOptions: [{}, {}, {}, {}, {}],
+      }).apply(compiler);
+
+      const stats = await compile(compiler);
+
+      errors = getErrors(stats);
+
+      for (const host of ["every-language.html", "every-language.css"]) {
+        assets[host] = readAsset(host, compiler, stats);
+      }
+    });
+
+    it("builds both hosts without an error", () => {
+      expect(errors).toEqual([]);
+    });
+
+    for (const { host, language, where, from, to, gone } of CASES) {
+      it(`minifies the ${language} in ${where} of ${host}`, () => {
+        expect(reached).toContainEqual({ language, code: from });
+        expect(assets[host]).toContain(to);
+        expect(assets[host]).not.toContain(gone);
+      });
+    }
+
+    it("reaches nothing beyond the bodies these cases name", () => {
+      const unaccounted = reached.filter(
+        ({ code }) => !CASES.some((testCase) => testCase.from === code),
+      );
+
+      // The three assets themselves — the bundle, the stylesheet and the
+      // document — are all that is minified beyond what they nest.
+      expect(unaccounted.map(({ language }) => language).sort()).toEqual([
+        "css",
+        "html",
+        "javascript",
+      ]);
+    });
+
+    it("matches snapshot", () => {
+      expect(assets).toMatchSnapshot("assets");
+    });
+  });
 });

--- a/test/fixtures/embedded/entry-every-language.js
+++ b/test/fixtures/embedded/entry-every-language.js
@@ -1,0 +1,4 @@
+console.log(
+  new URL("./every-language.html", import.meta.url),
+  new URL("./every-language.css", import.meta.url),
+);

--- a/test/fixtures/embedded/every-language.css
+++ b/test/fixtures/embedded/every-language.css
@@ -1,0 +1,5 @@
+.svg { background : url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'>   <rect  id='svgPayload'  />   </svg>") ; }
+.css { background : url("data:text/css,.cssPayload  {  color : #00ff00  }") ; }
+.html { background : url("data:text/html,<p   id='htmlPayload'   >hi</p>") ; }
+.json { background : url("data:application/json,{ \"jsonPayload\" :  1 }") ; }
+.js { background : url("data:text/javascript,var  jsPayload  =  1 ;") ; }

--- a/test/fixtures/embedded/every-language.html
+++ b/test/fixtures/embedded/every-language.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en"><head><title>x</title>
+<style>  .styleElement { color : #00ff00 }  </style>
+<script>  var  scriptElement  =  1 ;  function  f ( ) { return  scriptElement }  </script>
+<script type="application/json">  { "jsonElement" :  1 }  </script>
+</head><body>
+<p style="  color : #0000ff ;  ">hi</p>
+<svg xmlns="http://www.w3.org/2000/svg">   <rect  id="svgSubtree"  />   </svg>
+<iframe srcdoc="&lt;p   id=&quot;srcdocElement&quot;   &gt;hi&lt;/p&gt;"></iframe>
+</body></html>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

A document offers `renderEmbeddedSource` five languages — CSS twice, from a `<style>` element and from a `style` attribute — plus JavaScript, JSON, SVG and the document an `<iframe srcdoc>` holds; a stylesheet offers the same five through a `url()` `data:` payload. Eleven places in all, of which the suite covered two.

Each case names the exact body handed to the minimizer and the exact form that reaches the asset, so it asserts both halves: that this plugin was reached, and that its answer was written back. The first half matters on its own — webpack minifies an inline `<style>` and a JSON `<script>` with its own minifiers whether or not a minimizer here claims them, so the emitted bytes cannot tell the two apart. Verified by disabling the nested dispatch in `minify.js`: all eleven fail.

Two things found while writing them, neither addressed here:

- A `data:` payload inside a **custom property** (`--x: url("data:text/css,…")`) is offered to the minimizer and its answer is then discarded — the payload is emitted exactly as written. Only payloads in ordinary declarations are written back, so the cases use those.
- The whole file is **skipped on the webpack this repo locks** (5.109.2); `renderEmbeddedSource` ships from 5.110. That is pre-existing — the 18 cases already here are skipped too — and is described below.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

This is the tests: `test/embedded-source.test.js` gains eleven cases plus a snapshot of both emitted assets, over two fixtures (`every-language.html`, `every-language.css`). No source changes.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code enumerated the offer sites from webpack's own `EMBEDDED_LANGUAGES` lists rather than from the existing tests, then probed a real build to record what each minimizer is actually handed and what reaches the asset, and wrote the expectations from that. Each case was confirmed to fail with the nested dispatch disabled. The two findings above came out of that probing.

---
_Generated by [Claude Code](https://claude.ai/code/session_016TQeNpahUSDUjD2Crugy5H)_