### PR TITLE
docs: document the generate option, and correct what it supersedes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Using supported `devtool` values enable source map generation.
 - **[`parallel`](#parallel)**
 - **[`minify`](#minify)**
 - **[`minimizerOptions`](#minimizeroptions)**
+- **[`generate`](#generate)**
+- **[`generatorOptions`](#generatoroptions)**
 - **[`extractComments`](#extractcomments)**
 
 ### `test`
@@ -550,6 +552,110 @@ module.exports = {
       }),
     ],
   },
+};
+```
+
+### `generate`
+
+Type:
+
+```ts
+type generateFn = (
+  input: Record<string, string | Buffer>,
+  sourceMap: undefined,
+  generatorOptions: Record<string, any>,
+) => Promise<{
+  code: string | Buffer;
+  filename?: string;
+  errors?: (Error | string)[];
+  warnings?: (Error | string)[];
+}>;
+
+type generate = generateFn | generateFn[];
+```
+
+Default: `undefined`
+
+Rewrites a module's own bytes **as it is built**, rather than an asset after
+the build. That is the one point at which a re-encoding can also **rename** —
+return a `filename` and the asset is emitted under it, with every reference in
+the bundle following. [`minify`](#minify) cannot: an asset's name is decided
+during code generation, so renaming there would leave the bundle pointing at a
+URL nothing emits.
+
+[`test`](#test), [`include`](#include) and [`exclude`](#exclude) select which
+modules it sees, matched against the module's resource — query and all, so
+`?as=webp` is matchable. A generator runs **in the webpack process**, since
+modules build before the worker pool is up, and its answer is cached under the
+bytes plus the generator and its options.
+
+`sharpGenerate` is the bundled one. It takes the target format from the
+request's `?as=` or, failing that, from a
+[`generatorOptions.encodeOptions`](#generatoroptions) naming exactly one
+format, and reports an error when neither says which format to write:
+
+```js
+const MinimizerPlugin = require("minimizer-webpack-plugin");
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(jpe?g|png)$/i,
+        type: "asset/resource",
+        // The query has to survive into the name, or two formats of one image
+        // collide.
+        generator: { filename: "[name][ext][query]" },
+      },
+    ],
+  },
+  plugins: [
+    new MinimizerPlugin({
+      test: /\.(jpe?g|png)$/i,
+      generate: MinimizerPlugin.sharpGenerate,
+    }),
+  ],
+};
+```
+
+```js
+// `image.jpg` is emitted as `image.webp`, and this import points at it.
+import webp from "./image.jpg?as=webp";
+```
+
+> **Note**
+>
+> `generate` needs a webpack whose `NormalModule` `processResult` hook can be
+> awaited (**5.111** or newer). On an older webpack the plugin reports an error
+> rather than silently generating nothing.
+
+### `generatorOptions`
+
+Type:
+
+```ts
+type generatorOptions = Record<string, any> | Record<string, any>[];
+```
+
+Default: `{}`
+
+Options for [`generate`](#generate), exactly as
+[`minimizerOptions`](#minimizeroptions) is for [`minify`](#minify): one object
+for one generator, or an array positionally matching an array of generators.
+
+```js
+const MinimizerPlugin = require("minimizer-webpack-plugin");
+
+module.exports = {
+  plugins: [
+    new MinimizerPlugin({
+      test: /\.(jpe?g|png)$/i,
+      generate: MinimizerPlugin.sharpGenerate,
+      // Names the format when the request does not, and carries the encoder's
+      // own settings either way.
+      generatorOptions: { encodeOptions: { webp: { quality: 90 } } },
+    }),
+  ],
 };
 ```
 
@@ -1587,12 +1693,11 @@ npm install --save-dev imagemin imagemin-mozjpeg imagemin-pngquant
 
 > **Note**
 >
-> These minimizers **only minify** — they never change an image's format or
+> On `minify` these **only minify** — they never change an image's format or
 > name. An asset's name is decided during code generation, long before a
 > minimizer runs, so a renamed asset would leave the bundle pointing at a URL
-> nothing emits. Converting `.png` to `.webp` stays with
-> [`image-minimizer-webpack-plugin`](https://github.com/webpack/image-minimizer-webpack-plugin)
-> and its `generator` option.
+> nothing emits. Converting `.png` to `.webp` is what [`generate`](#generate)
+> is for: it runs while the module builds, early enough to rename.
 
 > **Note**
 >
@@ -1997,11 +2102,10 @@ could set that would mean the same thing twice over.
 
 > **Note**
 >
-> A query cannot pick a **format** here. `?as=webp` is read by
-> [`image-minimizer-webpack-plugin`](https://github.com/webpack/image-minimizer-webpack-plugin)'s
-> loader, which sees the import before an asset exists and can emit a different
-> file for it. Resizing needs no new name, which is why it works here; changing
-> the format does, and this plugin runs after names are decided.
+> A query cannot pick a **format** on this path. Resizing needs no new name,
+> which is why it works here; changing the format does, and `minify` runs after
+> names are decided. Hand `?as=webp` to [`generate`](#generate) instead, which
+> sees the module as it builds and can emit the new format under a new name.
 
 #### Images beside everything else
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`generate` and `generatorOptions` have been in `src/options.json` since the `processResult` hook landed in #711, and `sharpGenerate` is exported, but neither option was documented — `generatorOptions` appeared zero times in the README. The schema's own `link` fields already point at `#generate` and `#generatoroptions`, so a validation error linked to anchors that did not exist. This adds both sections.

Two existing Notes said the opposite of what the plugin now does: that these minimizers "never change an image's format or name" and that converting `.png` to `.webp` "stays with `image-minimizer-webpack-plugin`", and that `?as=webp` is read by that plugin's loader. `generate` receives the module's resource with its query and can return a `filename`, and `sharpGenerate` reads `?as=` — so both claims are now wrong. Each note now says which path it applies to and points at `generate`.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

docs

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No — documentation only, no source change. The behaviour described is already covered by `test/generate-option.test.js`; see **Use of AI** for how it was checked, since that suite self-skips on the webpack this repo locks.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

This is the documentation. Worth knowing separately: `generate` needs the awaitable `NormalModule.processResult` hook, which is in no released webpack yet — it is on webpack `main` (5.110.3) from webpack/webpack#21854 and no release tag contains it. The plugin's own error message names 5.111, which the new section repeats.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code wrote the sections from the implementation rather than from the existing prose — the schema, the `generate()` method, and `sharpGenerate`'s format selection. `test/generate-option.test.js` passes trivially here because it self-skips on webpack 5.109.2, which this repo locks, so it was re-run against webpack `main` with the skip guard temporarily made fatal, to confirm the eleven cases really exercise the rename, the query and fragment surviving, the filters, and the format-ambiguity errors before any of it was written down.

---
_Generated by [Claude Code](https://claude.ai/code/session_016TQeNpahUSDUjD2Crugy5H)_