### PR TITLE
feat: add the severityError option

### DIFF
--- a/.changeset/severity-error.md
+++ b/.changeset/severity-error.md
@@ -1,0 +1,5 @@
+---
+"minimizer-webpack-plugin": minor
+---
+
+add the `severityError` option, choosing whether a minimizer's own errors fail the build (`"error"`, the default), are filed among the warnings (`"warning"`), or are dropped along with its warnings (`"off"`)

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Using supported `devtool` values enable source map generation.
 - **[`minimizerOptions`](#minimizeroptions)**
 - **[`generate`](#generate)**
 - **[`generatorOptions`](#generatoroptions)**
+- **[`severityError`](#severityerror)**
 - **[`extractComments`](#extractcomments)**
 
 ### `test`
@@ -656,6 +657,42 @@ module.exports = {
       generatorOptions: { encodeOptions: { webp: { quality: 90 } } },
     }),
   ],
+};
+```
+
+### `severityError`
+
+Type:
+
+```ts
+type severityError = "off" | "warning" | "error";
+```
+
+Default: `"error"`
+
+How a **minimizer's own** diagnostics are filed: what it reported, and what it
+threw. `"warning"` files its errors among the warnings, so a build that cannot
+minify one asset still succeeds; `"off"` files neither its errors nor its
+warnings.
+
+This does not reach the plugin's own diagnostics — an invalid source map, or a
+[`generate`](#generate) asked of a webpack too old to await — which are
+reported whatever this says, since silencing them would hide the reason nothing
+ran.
+
+```js
+const MinimizerPlugin = require("minimizer-webpack-plugin");
+
+module.exports = {
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new MinimizerPlugin({
+        // One asset this minimizer chokes on should not fail the build.
+        severityError: "warning",
+      }),
+    ],
+  },
 };
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -193,6 +193,8 @@ const {
  * @typedef {undefined | boolean | number} Parallel
  */
 
+/** @typedef {"off" | "warning" | "error"} SeverityError */
+
 /**
  * @typedef {object} BasePluginOptions
  * @property {Rules=} test test rule
@@ -202,6 +204,7 @@ const {
  * @property {Parallel=} parallel parallel option
  * @property {MinimizerImplementation<EXPECTED_ANY>=} generate rewrites a module's own bytes as it is built, so a re-encoding can rename the asset
  * @property {MinimizerOptions<EXPECTED_ANY>=} generatorOptions options for `generate`
+ * @property {SeverityError=} severityError how a minimizer's own errors are reported
  */
 
 /**
@@ -255,6 +258,7 @@ class TerserPlugin {
       exclude,
       generate,
       generatorOptions,
+      severityError = "error",
     } = this.rawOptions;
 
     // `terserOptions` is a deprecated alias of `minimizerOptions`; prefer the
@@ -277,6 +281,7 @@ class TerserPlugin {
       parallel,
       include,
       exclude,
+      severityError,
       minimizer: {
         implementation: minify,
         options: resolvedMinimizerOptions,
@@ -747,7 +752,7 @@ class TerserPlugin {
             const hasSourceMap =
               inputSourceMap && TerserPlugin.isSourceMap(inputSourceMap);
 
-            compilation.errors.push(
+            this.report(compilation, [
               TerserPlugin.buildError(
                 /** @type {Error | ErrorObject | string} */
                 (error),
@@ -761,17 +766,17 @@ class TerserPlugin {
 
                 hasSourceMap ? compilation.requestShortener : undefined,
               ),
-            );
+            ]);
 
             return;
           }
 
           if (typeof output.code === "undefined") {
-            compilation.errors.push(
+            this.report(compilation, [
               new Error(
                 `${name} from Terser plugin\nMinimizer doesn't return result`,
               ),
-            );
+            ]);
           }
 
           if (output.warnings && output.warnings.length > 0) {
@@ -917,17 +922,7 @@ class TerserPlugin {
           });
         }
 
-        if (output.warnings && output.warnings.length > 0) {
-          for (const warning of output.warnings) {
-            compilation.warnings.push(warning);
-          }
-        }
-
-        if (output.errors && output.errors.length > 0) {
-          for (const error of output.errors) {
-            compilation.errors.push(error);
-          }
-        }
+        this.report(compilation, output.errors, output.warnings);
 
         // Emit extracted comments file even if the main asset was not
         // rewritten (some minimizers only produce comments / warnings / errors)
@@ -1129,6 +1124,35 @@ class TerserPlugin {
   }
 
   /**
+   * Routes what a minimizer reported into the compilation, as `severityError`
+   * asks: `"off"` files neither, `"warning"` files its errors as warnings.
+   * @private
+   * @param {Compilation} compilation compilation
+   * @param {(Error[])=} errors what the minimizer reported as errors
+   * @param {(Error[])=} warnings what it reported as warnings
+   * @returns {void}
+   */
+  report(compilation, errors, warnings) {
+    const { severityError } = this.options;
+
+    if (severityError === "off") {
+      return;
+    }
+
+    for (const warning of warnings || []) {
+      compilation.warnings.push(warning);
+    }
+
+    for (const error of errors || []) {
+      if (severityError === "warning") {
+        compilation.warnings.push(error);
+      } else {
+        compilation.errors.push(error);
+      }
+    }
+  }
+
+  /**
    * Minify one source a module embeds in another language's output — CSS or
    * HTML reaching the bundle inside a JavaScript string literal, an
    * `asset/source` file's text, an `asset/inline` payload. No asset carries
@@ -1225,12 +1249,12 @@ class TerserPlugin {
           ),
         });
       } catch (error) {
-        compilation.errors.push(
+        this.report(compilation, [
           TerserPlugin.buildError(
             /** @type {Error | ErrorObject | string} */ (error),
             name,
           ),
-        );
+        ]);
 
         return source;
       }
@@ -1269,13 +1293,11 @@ class TerserPlugin {
       await cacheItem.storePromise(output);
     }
 
-    for (const error of /** @type {Error[]} */ (output.errors || [])) {
-      compilation.errors.push(error);
-    }
-
-    for (const warning of /** @type {Error[]} */ (output.warnings || [])) {
-      compilation.warnings.push(warning);
-    }
+    this.report(
+      compilation,
+      /** @type {Error[]} */ (output.errors),
+      /** @type {Error[]} */ (output.warnings),
+    );
 
     return output.source;
   }
@@ -1339,12 +1361,12 @@ class TerserPlugin {
           ),
         });
       } catch (error) {
-        compilation.errors.push(
+        this.report(compilation, [
           TerserPlugin.buildError(
             /** @type {Error | ErrorObject | string} */ (error),
             resource,
           ),
-        );
+        ]);
 
         return result;
       }
@@ -1371,13 +1393,11 @@ class TerserPlugin {
       await cacheItem.storePromise(output);
     }
 
-    for (const error of /** @type {Error[]} */ (output.errors || [])) {
-      compilation.errors.push(error);
-    }
-
-    for (const warning of /** @type {Error[]} */ (output.warnings || [])) {
-      compilation.warnings.push(warning);
-    }
+    this.report(
+      compilation,
+      /** @type {Error[]} */ (output.errors),
+      /** @type {Error[]} */ (output.warnings),
+    );
 
     // Naming the asset after what it now is. `assetResource` is serialized with
     // the module, so the rename survives a restore from the persistent cache,

--- a/src/options.json
+++ b/src/options.json
@@ -234,6 +234,11 @@
           }
         }
       ]
+    },
+    "severityError": {
+      "description": "Allows to choose how a minimizer's own errors are reported.",
+      "link": "https://github.com/webpack/minimizer-webpack-plugin#severityerror",
+      "enum": ["off", "warning", "error"]
     }
   }
 }

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -3,7 +3,7 @@
 exports[`validation should validate a minimizer added through \`optimization.minimizer\` 1`] = `
 "Invalid options object. Terser Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { test?, include?, exclude?, minimizerOptions?, terserOptions?, extractComments?, parallel?, minify?, generate?, generatorOptions? }"
+   object { test?, include?, exclude?, minimizerOptions?, terserOptions?, extractComments?, parallel?, minify?, generate?, generatorOptions?, severityError? }"
 `;
 
 exports[`validation validate 1`] = `
@@ -219,7 +219,7 @@ exports[`validation validate 16`] = `
 exports[`validation validate 17`] = `
 "Invalid options object. Terser Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { test?, include?, exclude?, minimizerOptions?, terserOptions?, extractComments?, parallel?, minify?, generate?, generatorOptions? }"
+   object { test?, include?, exclude?, minimizerOptions?, terserOptions?, extractComments?, parallel?, minify?, generate?, generatorOptions?, severityError? }"
 `;
 
 exports[`validation validate 18`] = `
@@ -238,4 +238,20 @@ exports[`validation validate 19`] = `
       object { … }
     * options.minimizerOptions should be an array:
       [object { … }, ...] (should not have fewer than 1 item)"
+`;
+
+exports[`validation validate severityError 1`] = `
+"Invalid options object. Terser Plugin has been initialized using an options object that does not match the API schema.
+ - options.severityError should be one of these:
+   "off" | "warning" | "error"
+   -> Allows to choose how a minimizer's own errors are reported.
+   -> Read more at https://github.com/webpack/minimizer-webpack-plugin#severityerror"
+`;
+
+exports[`validation validate severityError 2`] = `
+"Invalid options object. Terser Plugin has been initialized using an options object that does not match the API schema.
+ - options.severityError should be one of these:
+   "off" | "warning" | "error"
+   -> Allows to choose how a minimizer's own errors are reported.
+   -> Read more at https://github.com/webpack/minimizer-webpack-plugin#severityerror"
 `;

--- a/test/severityError-option.test.js
+++ b/test/severityError-option.test.js
@@ -118,3 +118,122 @@ describe.each([false, true])(
     });
   },
 );
+
+/**
+ * Stands an awaitable hook in for `NormalModule`'s `processResult`, which is
+ * synchronous in every webpack released so far. The plugin taps it to reach
+ * `generate`, so without this the whole path is unreachable; the promises it
+ * starts are handed back for the test to await.
+ */
+class AwaitableProcessResult {
+  constructor() {
+    this.pending = [];
+  }
+
+  /**
+   * @param {import("webpack").Compiler} compiler compiler
+   * @returns {void}
+   */
+  apply(compiler) {
+    compiler.hooks.compilation.tap("AwaitableProcessResult", (compilation) => {
+      const hooks =
+        compiler.webpack.NormalModule.getCompilationHooks(compilation);
+      const taps = [];
+
+      hooks.processResult = {
+        tapPromise: (name, fn) => {
+          taps.push(fn);
+        },
+        call: (result, module) => {
+          for (const fn of taps) {
+            this.pending.push(fn(result, module));
+          }
+
+          return result;
+        },
+      };
+    });
+  }
+}
+
+/**
+ * @param {{ [file: string]: string }} input what the module built to
+ * @returns {{ code: string }} the same bytes
+ */
+function passthrough(input) {
+  const [[, code]] = Object.entries(input);
+
+  return { code };
+}
+
+/**
+ * @param {object=} options plugin options beyond the generator
+ * @param {(() => never) | (() => { code: string, errors: string[], warnings: string[] })} generate what the generator does
+ * @returns {Promise<import("webpack").Stats>} the stats of the build
+ */
+async function buildGenerated(options, generate) {
+  const awaitable = new AwaitableProcessResult();
+  const compiler = getCompiler({
+    entry: path.resolve(__dirname, "./fixtures/minify/es6.js"),
+    output: {
+      path: path.resolve(__dirname, "./dist-terser"),
+      filename: "[name].js",
+      chunkFilename: "[id].[name].js",
+    },
+  });
+
+  awaitable.apply(compiler);
+
+  new MinimizerPlugin({ ...options, minify: passthrough, generate }).apply(
+    compiler,
+  );
+
+  const stats = await compile(compiler);
+
+  await Promise.all(awaitable.pending);
+
+  return stats;
+}
+
+describe('"severityError" option (generate)', () => {
+  it("should file what a generator reported as errors by default", async () => {
+    const stats = await buildGenerated(undefined, reportsBoth);
+
+    expect(getErrors(stats).join("\n")).toContain("reported error");
+    expect(getWarnings(stats).join("\n")).toContain("reported warning");
+  });
+
+  it('should file what a generator reported as warnings when "warning"', async () => {
+    const stats = await buildGenerated(
+      { severityError: "warning" },
+      reportsBoth,
+    );
+
+    expect(getErrors(stats)).toEqual([]);
+
+    const warnings = getWarnings(stats).join("\n");
+
+    expect(warnings).toContain("reported error");
+    expect(warnings).toContain("reported warning");
+  });
+
+  it('should file neither when "off"', async () => {
+    const stats = await buildGenerated({ severityError: "off" }, reportsBoth);
+
+    expect(getErrors(stats)).toEqual([]);
+    expect(getWarnings(stats)).toEqual([]);
+  });
+
+  it("should file what a generator threw as an error by default", async () => {
+    const stats = await buildGenerated(undefined, throws);
+
+    expect(getErrors(stats).join("\n")).toContain("thrown");
+  });
+
+  it('should file what a generator threw as a warning when "warning"', async () => {
+    const stats = await buildGenerated({ severityError: "warning" }, throws);
+
+    expect(getErrors(stats)).toEqual([]);
+    expect(getWarnings(stats).join("\n")).toContain("thrown");
+  });
+});

--- a/test/severityError-option.test.js
+++ b/test/severityError-option.test.js
@@ -1,0 +1,100 @@
+import path from "path";
+
+import MinimizerPlugin from "../src";
+
+import { compile, getCompiler, getErrors, getWarnings } from "./helpers";
+
+/**
+ * @param {object=} options plugin options beyond the minimizer
+ * @param {(() => never) | (() => { code: string, errors: Error[], warnings: Error[] })} minify what the minimizer does
+ * @returns {Promise<import("webpack").Stats>} the stats of the build
+ */
+async function build(options, minify) {
+  const compiler = getCompiler({
+    entry: path.resolve(__dirname, "./fixtures/minify/es6.js"),
+    output: {
+      path: path.resolve(__dirname, "./dist-terser"),
+      filename: "[name].js",
+      chunkFilename: "[id].[name].js",
+    },
+  });
+
+  new MinimizerPlugin({ ...options, minify }).apply(compiler);
+
+  return compile(compiler);
+}
+
+/**
+ * A minimizer that reports one of each rather than throwing.
+ * @returns {{ code: string, errors: Error[], warnings: Error[] }} what it reported
+ */
+function reportsBoth() {
+  return {
+    code: "0",
+    errors: [new Error("reported error")],
+    warnings: [new Error("reported warning")],
+  };
+}
+
+/**
+ * A minimizer that throws, which the plugin files as an error of its own.
+ * @returns {never} nothing; it always throws
+ */
+function throws() {
+  throw new Error("thrown");
+}
+
+describe('"severityError" option', () => {
+  it("should file errors as errors by default", async () => {
+    const stats = await build(undefined, reportsBoth);
+
+    expect(getErrors(stats).join("\n")).toContain("reported error");
+    expect(getWarnings(stats).join("\n")).toContain("reported warning");
+  });
+
+  it('should file errors as errors when "error"', async () => {
+    const stats = await build({ severityError: "error" }, reportsBoth);
+
+    expect(getErrors(stats).join("\n")).toContain("reported error");
+    expect(getWarnings(stats).join("\n")).toContain("reported warning");
+  });
+
+  it('should file errors as warnings when "warning"', async () => {
+    const stats = await build({ severityError: "warning" }, reportsBoth);
+
+    expect(getErrors(stats)).toEqual([]);
+
+    const warnings = getWarnings(stats).join("\n");
+
+    expect(warnings).toContain("reported error");
+    expect(warnings).toContain("reported warning");
+  });
+
+  it('should file neither when "off"', async () => {
+    const stats = await build({ severityError: "off" }, reportsBoth);
+
+    expect(getErrors(stats)).toEqual([]);
+    expect(getWarnings(stats)).toEqual([]);
+  });
+
+  it("should file what a minimizer threw as an error by default", async () => {
+    const stats = await build(undefined, throws);
+
+    expect(getErrors(stats).join("\n")).toContain("thrown");
+    expect(getWarnings(stats)).toEqual([]);
+  });
+
+  it('should file what a minimizer threw as a warning when "warning"', async () => {
+    const stats = await build({ severityError: "warning" }, throws);
+
+    expect(getErrors(stats)).toEqual([]);
+    expect(getWarnings(stats).join("\n")).toContain("thrown");
+  });
+
+  it('should file nothing a minimizer threw when "off"', async () => {
+    const stats = await build({ severityError: "off" }, throws);
+
+    expect(getErrors(stats)).toEqual([]);
+    expect(getWarnings(stats)).toEqual([]);
+  });
+});

--- a/test/severityError-option.test.js
+++ b/test/severityError-option.test.js
@@ -6,10 +6,11 @@ import { compile, getCompiler, getErrors, getWarnings } from "./helpers";
 
 /**
  * @param {object=} options plugin options beyond the minimizer
- * @param {(() => never) | (() => { code: string, errors: Error[], warnings: Error[] })} minify what the minimizer does
+ * @param {(() => never) | (() => { code: string, errors: string[], warnings: string[] })} minify what the minimizer does
+ * @param {boolean} parallel whether the minimizer runs in the worker pool
  * @returns {Promise<import("webpack").Stats>} the stats of the build
  */
-async function build(options, minify) {
+async function build(options, minify, parallel) {
   const compiler = getCompiler({
     entry: path.resolve(__dirname, "./fixtures/minify/es6.js"),
     output: {
@@ -19,20 +20,22 @@ async function build(options, minify) {
     },
   });
 
-  new MinimizerPlugin({ ...options, minify }).apply(compiler);
+  new MinimizerPlugin({ parallel, ...options, minify }).apply(compiler);
 
   return compile(compiler);
 }
 
 /**
- * A minimizer that reports one of each rather than throwing.
- * @returns {{ code: string, errors: Error[], warnings: Error[] }} what it reported
+ * A minimizer that reports one of each rather than throwing. It reports them as
+ * strings, the other form the contract takes: an `Error` does not survive the
+ * worker boundary, so one would arrive with its message lost.
+ * @returns {{ code: string, errors: string[], warnings: string[] }} what it reported
  */
 function reportsBoth() {
   return {
     code: "0",
-    errors: [new Error("reported error")],
-    warnings: [new Error("reported warning")],
+    errors: ["reported error"],
+    warnings: ["reported warning"],
   };
 }
 
@@ -44,57 +47,74 @@ function throws() {
   throw new Error("thrown");
 }
 
-describe('"severityError" option', () => {
-  it("should file errors as errors by default", async () => {
-    const stats = await build(undefined, reportsBoth);
+// Both paths, because a minimizer's diagnostics cross the worker boundary on
+// one of them and not the other.
+describe.each([false, true])(
+  '"severityError" option (parallel: %s)',
+  (parallel) => {
+    it("should file errors as errors by default", async () => {
+      const stats = await build(undefined, reportsBoth, parallel);
 
-    expect(getErrors(stats).join("\n")).toContain("reported error");
-    expect(getWarnings(stats).join("\n")).toContain("reported warning");
-  });
+      expect(getErrors(stats).join("\n")).toContain("reported error");
+      expect(getWarnings(stats).join("\n")).toContain("reported warning");
+    });
 
-  it('should file errors as errors when "error"', async () => {
-    const stats = await build({ severityError: "error" }, reportsBoth);
+    it('should file errors as errors when "error"', async () => {
+      const stats = await build(
+        { severityError: "error" },
+        reportsBoth,
+        parallel,
+      );
 
-    expect(getErrors(stats).join("\n")).toContain("reported error");
-    expect(getWarnings(stats).join("\n")).toContain("reported warning");
-  });
+      expect(getErrors(stats).join("\n")).toContain("reported error");
+      expect(getWarnings(stats).join("\n")).toContain("reported warning");
+    });
 
-  it('should file errors as warnings when "warning"', async () => {
-    const stats = await build({ severityError: "warning" }, reportsBoth);
+    it('should file errors as warnings when "warning"', async () => {
+      const stats = await build(
+        { severityError: "warning" },
+        reportsBoth,
+        parallel,
+      );
 
-    expect(getErrors(stats)).toEqual([]);
+      expect(getErrors(stats)).toEqual([]);
 
-    const warnings = getWarnings(stats).join("\n");
+      const warnings = getWarnings(stats).join("\n");
 
-    expect(warnings).toContain("reported error");
-    expect(warnings).toContain("reported warning");
-  });
+      expect(warnings).toContain("reported error");
+      expect(warnings).toContain("reported warning");
+    });
 
-  it('should file neither when "off"', async () => {
-    const stats = await build({ severityError: "off" }, reportsBoth);
+    it('should file neither when "off"', async () => {
+      const stats = await build(
+        { severityError: "off" },
+        reportsBoth,
+        parallel,
+      );
 
-    expect(getErrors(stats)).toEqual([]);
-    expect(getWarnings(stats)).toEqual([]);
-  });
+      expect(getErrors(stats)).toEqual([]);
+      expect(getWarnings(stats)).toEqual([]);
+    });
 
-  it("should file what a minimizer threw as an error by default", async () => {
-    const stats = await build(undefined, throws);
+    it("should file what a minimizer threw as an error by default", async () => {
+      const stats = await build(undefined, throws, parallel);
 
-    expect(getErrors(stats).join("\n")).toContain("thrown");
-    expect(getWarnings(stats)).toEqual([]);
-  });
+      expect(getErrors(stats).join("\n")).toContain("thrown");
+      expect(getWarnings(stats)).toEqual([]);
+    });
 
-  it('should file what a minimizer threw as a warning when "warning"', async () => {
-    const stats = await build({ severityError: "warning" }, throws);
+    it('should file what a minimizer threw as a warning when "warning"', async () => {
+      const stats = await build({ severityError: "warning" }, throws, parallel);
 
-    expect(getErrors(stats)).toEqual([]);
-    expect(getWarnings(stats).join("\n")).toContain("thrown");
-  });
+      expect(getErrors(stats)).toEqual([]);
+      expect(getWarnings(stats).join("\n")).toContain("thrown");
+    });
 
-  it('should file nothing a minimizer threw when "off"', async () => {
-    const stats = await build({ severityError: "off" }, throws);
+    it('should file nothing a minimizer threw when "off"', async () => {
+      const stats = await build({ severityError: "off" }, throws, parallel);
 
-    expect(getErrors(stats)).toEqual([]);
-    expect(getWarnings(stats)).toEqual([]);
-  });
-});
+      expect(getErrors(stats)).toEqual([]);
+      expect(getWarnings(stats)).toEqual([]);
+    });
+  },
+);

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -344,6 +344,28 @@ describe("validation", () => {
     }).not.toThrow();
   });
 
+  it("validate severityError", () => {
+    expect(() => {
+      createCompiler({ severityError: "off" });
+    }).not.toThrow();
+
+    expect(() => {
+      createCompiler({ severityError: "warning" });
+    }).not.toThrow();
+
+    expect(() => {
+      createCompiler({ severityError: "error" });
+    }).not.toThrow();
+
+    expect(() => {
+      createCompiler({ severityError: "nope" });
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      createCompiler({ severityError: true });
+    }).toThrowErrorMatchingSnapshot();
+  });
+
   it("should validate a minimizer added through `optimization.minimizer`", () => {
     expect(() => {
       getCompiler({

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -90,6 +90,16 @@ declare class TerserPlugin<T = import("terser").MinifyOptions> {
    */
   private embeddedMinimizer;
   /**
+   * Routes what a minimizer reported into the compilation, as `severityError`
+   * asks: `"off"` files neither, `"warning"` files its errors as warnings.
+   * @private
+   * @param {Compilation} compilation compilation
+   * @param {(Error[])=} errors what the minimizer reported as errors
+   * @param {(Error[])=} warnings what it reported as warnings
+   * @returns {void}
+   */
+  private report;
+  /**
    * Minify one source a module embeds in another language's output — CSS or
    * HTML reaching the bundle inside a JavaScript string literal, an
    * `asset/source` file's text, an `asset/inline` payload. No asset carries
@@ -190,6 +200,7 @@ declare namespace TerserPlugin {
     InternalOptions,
     MinimizerWorker,
     Parallel,
+    SeverityError,
     BasePluginOptions,
     DefinedDefaultMinimizerAndOptions,
     InternalPluginOptions,
@@ -493,6 +504,7 @@ type MinimizerWorker<T> = JestWorker & {
   minify: (options: InternalOptions<T>) => Promise<MinimizedResult>;
 };
 type Parallel = undefined | boolean | number;
+type SeverityError = "off" | "warning" | "error";
 type BasePluginOptions = {
   /**
    * test rule
@@ -522,6 +534,10 @@ type BasePluginOptions = {
    * options for `generate`
    */
   generatorOptions?: MinimizerOptions<EXPECTED_ANY> | undefined;
+  /**
+   * how a minimizer's own errors are reported
+   */
+  severityError?: SeverityError | undefined;
 };
 type DefinedDefaultMinimizerAndOptions<T> =
   T extends import("terser").MinifyOptions


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

`image-minimizer-webpack-plugin` lets a build choose how a minimizer's own failures are reported, which matters most for images — one asset an encoder chokes on should not have to fail the whole build. This brings the option across as part of folding that plugin in.

`"warning"` files a minimizer's errors among the warnings, `"off"` files neither those nor its warnings, and the default `"error"` is what happens today, so nothing changes for an existing config. It covers both what a minimizer reported and what it threw, on all three paths — the worker pool, the in-process one `sharp` and `imagemin` take, and `generate` — routed through one helper rather than repeated at each of the seven sites.

The plugin's own diagnostics deliberately stay out of it: an invalid source map, or a `generate` asked of a webpack that cannot await, is reported whatever this says, since silencing those would hide the reason nothing ran.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes. `test/severityError-option.test.js` covers all three values against both a minimizer that reports diagnostics and one that throws, and `test/validate-options.test.js` gains the schema cases. Two existing snapshots there move because the new property joins the "valid properties" list. Full suite: 393 tests, 825 snapshots, 20 suites, all passing.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No — the default preserves today's behaviour exactly.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

Documented here: a `severityError` section plus its entry in the options list.

Note for merge order: #719 documents `generate`, and this section refers to `generate` in prose. If #719 lands first, that mention is worth turning into a `#generate` link; it is deliberately unlinked here so this PR stands alone on `main`.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code made the change. It located every diagnostic site by reading them rather than by pattern-matching, which is what separated the seven minimizer-produced ones from the two structural ones that must not be silenced, and it checked the semantics against `image-minimizer-webpack-plugin`'s own `processSeverityError` so `"off"` and `"warning"` behave the same way there as here.

---
_Generated by [Claude Code](https://claude.ai/code/session_016TQeNpahUSDUjD2Crugy5H)_